### PR TITLE
Fixed an issue with unrolling a dict in message

### DIFF
--- a/influxdb_logging/handler.py
+++ b/influxdb_logging/handler.py
@@ -121,11 +121,11 @@ class InfluxHandler(logging.Handler):
         if value is None:
             return
         elif isinstance(value, dict):
-            for k in value.items():
+            for k,v in value.items():
                 if key:
-                    self._convert_to_point(key + '.' + k, value[k], fields, tags)
+                    self._convert_to_point(key + '.' + k, v, fields, tags)
                 else:
-                    self._convert_to_point(k, value[k], fields, tags)
+                    self._convert_to_point(k, v, fields, tags)
         elif isinstance(value, list):
             self._convert_to_point(key, ' '.join(value), fields, tags)
         else:


### PR DESCRIPTION
When passing a dictionary as a log message parameter the handler fails to unroll it. Resulting error is "can not add tuple to a string".